### PR TITLE
Add extendable chess engine and demo GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # ChessEngine
+
+This repository provides a small JavaScript chess engine that is intended to be
+extended through a simple plugin system. A basic web interface is included in
+the `web/` directory as an example of how the engine can be consumed.
+
+## Structure
+
+- `engine/` – standalone engine library that can be imported in browsers or
+  other JavaScript environments.
+- `web/` – minimal GUI built on top of the engine using vanilla JavaScript and
+  HTML.
+
+## Usage
+
+Open `web/index.html` in a modern browser to play. Moves are validated using the
+standard chess rules implemented in the engine. Plugins can hook into the
+`beforeMove` and `afterMove` events of the `ChessEngine` class to introduce new
+rules or features.
+
+## Extending
+
+Create an object with `beforeMove(engine, piece, move)` or `afterMove(engine,
+piece, move)` methods and register it using `engine.addPlugin(plugin)`. Returning
+`false` from `beforeMove` prevents the move from being made. This mechanism
+allows rules such as castling, en passant or custom pieces to be added without
+modifying the core engine.
+
+## License
+
+See [LICENSE](LICENSE) for license information.

--- a/engine/index.js
+++ b/engine/index.js
@@ -1,0 +1,128 @@
+export class ChessEngine {
+  constructor() {
+    this.plugins = [];
+    this.reset();
+  }
+
+  reset() {
+    // initialize empty 8x8 board
+    this.board = Array.from({ length: 8 }, () => Array(8).fill(null));
+    this.turn = 'white';
+    this._placePieces();
+  }
+
+  _placePieces() {
+    const backRank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'];
+    // place white pieces
+    for (let i = 0; i < 8; i++) {
+      this.board[0][i] = { type: backRank[i], color: 'white' };
+      this.board[1][i] = { type: 'pawn', color: 'white' };
+      this.board[6][i] = { type: 'pawn', color: 'black' };
+      this.board[7][i] = { type: backRank[i], color: 'black' };
+    }
+  }
+
+  addPlugin(plugin) {
+    this.plugins.push(plugin);
+  }
+
+  getPiece(x, y) {
+    return this.board[y]?.[x] || null;
+  }
+
+  move(fromX, fromY, toX, toY) {
+    const piece = this.getPiece(fromX, fromY);
+    if (!piece) return false;
+    if (piece.color !== this.turn) return false;
+
+    for (const p of this.plugins) {
+      if (p.beforeMove && p.beforeMove(this, piece, { fromX, fromY, toX, toY }) === false) {
+        return false;
+      }
+    }
+
+    if (!this.isValidMove(piece, fromX, fromY, toX, toY)) return false;
+
+    this.board[toY][toX] = piece;
+    this.board[fromY][fromX] = null;
+    this.turn = this.turn === 'white' ? 'black' : 'white';
+
+    for (const p of this.plugins) {
+      if (p.afterMove) p.afterMove(this, piece, { fromX, fromY, toX, toY });
+    }
+
+    return true;
+  }
+
+  isValidMove(piece, fromX, fromY, toX, toY) {
+    const dx = toX - fromX;
+    const dy = toY - fromY;
+    const target = this.getPiece(toX, toY);
+    if (target && target.color === piece.color) return false;
+
+    switch (piece.type) {
+      case 'pawn':
+        return this._validatePawnMove(piece, fromX, fromY, toX, toY, dx, dy, target);
+      case 'rook':
+        return this._validateRookMove(fromX, fromY, toX, toY);
+      case 'bishop':
+        return this._validateBishopMove(fromX, fromY, toX, toY);
+      case 'queen':
+        return (
+          this._validateRookMove(fromX, fromY, toX, toY) ||
+          this._validateBishopMove(fromX, fromY, toX, toY)
+        );
+      case 'king':
+        return Math.max(Math.abs(dx), Math.abs(dy)) === 1;
+      case 'knight':
+        return (
+          (Math.abs(dx) === 2 && Math.abs(dy) === 1) ||
+          (Math.abs(dx) === 1 && Math.abs(dy) === 2)
+        );
+      default:
+        return false;
+    }
+  }
+
+  _validatePawnMove(piece, fromX, fromY, toX, toY, dx, dy, target) {
+    const dir = piece.color === 'white' ? 1 : -1;
+    const startRow = piece.color === 'white' ? 1 : 6;
+
+    if (dx === 0) {
+      if (dy === dir && !target) return true;
+      if (fromY === startRow && dy === 2 * dir && !target && !this.getPiece(fromX, fromY + dir)) return true;
+    }
+    if (Math.abs(dx) === 1 && dy === dir && target && target.color !== piece.color) return true;
+    return false;
+  }
+
+  _validateRookMove(fromX, fromY, toX, toY) {
+    if (fromX !== toX && fromY !== toY) return false;
+    const stepX = Math.sign(toX - fromX);
+    const stepY = Math.sign(toY - fromY);
+    let x = fromX + stepX;
+    let y = fromY + stepY;
+    while (x !== toX || y !== toY) {
+      if (this.getPiece(x, y)) return false;
+      x += stepX;
+      y += stepY;
+    }
+    return true;
+  }
+
+  _validateBishopMove(fromX, fromY, toX, toY) {
+    const dx = toX - fromX;
+    const dy = toY - fromY;
+    if (Math.abs(dx) !== Math.abs(dy)) return false;
+    const stepX = Math.sign(dx);
+    const stepY = Math.sign(dy);
+    let x = fromX + stepX;
+    let y = fromY + stepY;
+    while (x !== toX && y !== toY) {
+      if (this.getPiece(x, y)) return false;
+      x += stepX;
+      y += stepY;
+    }
+    return true;
+  }
+}

--- a/engine/package.json
+++ b/engine/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "chessengine",
+  "version": "0.1.0",
+  "main": "index.js",
+  "type": "module",
+  "description": "Base Chess Engine with plugin support"
+}

--- a/engine/plugins.js
+++ b/engine/plugins.js
@@ -1,0 +1,5 @@
+export class LoggerPlugin {
+  beforeMove(engine, piece, move) {
+    console.log(`Moving ${piece.color} ${piece.type} from ${move.fromX},${move.fromY} to ${move.toX},${move.toY}`);
+  }
+}

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,55 @@
+import { ChessEngine } from '../engine/index.js';
+import { LoggerPlugin } from '../engine/plugins.js';
+
+const boardEl = document.getElementById('board');
+const engine = new ChessEngine();
+engine.addPlugin(new LoggerPlugin());
+
+const pieceSymbols = {
+  pawn:   { white: '♙', black: '♟' },
+  rook:   { white: '♖', black: '♜' },
+  knight: { white: '♘', black: '♞' },
+  bishop: { white: '♗', black: '♝' },
+  queen:  { white: '♕', black: '♛' },
+  king:   { white: '♔', black: '♚' }
+};
+
+let selected = null;
+
+function render() {
+  boardEl.innerHTML = '';
+  for (let y = 7; y >= 0; y--) {
+    for (let x = 0; x < 8; x++) {
+      const square = document.createElement('div');
+      square.className = 'square ' + ((x + y) % 2 ? 'dark' : 'light');
+      square.dataset.x = x;
+      square.dataset.y = y;
+      const piece = engine.getPiece(x, y);
+      if (piece) {
+        square.textContent = pieceSymbols[piece.type][piece.color];
+      }
+      square.addEventListener('click', onSquareClick);
+      boardEl.appendChild(square);
+    }
+  }
+}
+
+function onSquareClick(e) {
+  const x = parseInt(e.currentTarget.dataset.x, 10);
+  const y = parseInt(e.currentTarget.dataset.y, 10);
+  if (selected) {
+    if (engine.move(selected.x, selected.y, x, y)) {
+      selected = null;
+      render();
+      return;
+    }
+    selected = null;
+  } else {
+    const piece = engine.getPiece(x, y);
+    if (piece && piece.color === engine.turn) {
+      selected = { x, y };
+    }
+  }
+}
+
+render();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ChessEngine Demo</title>
+  <style>
+    #board {
+      display: grid;
+      grid-template-columns: repeat(8, 50px);
+      grid-template-rows: repeat(8, 50px);
+      width: 400px;
+    }
+    .square {
+      width: 50px;
+      height: 50px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+    }
+    .light { background: #eee; }
+    .dark { background: #555; color: white; }
+  </style>
+</head>
+<body>
+  <div id="board"></div>
+  <script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a simple chess engine in `engine/`
- expose plugin hook system and example `LoggerPlugin`
- add minimal GUI in `web/` that uses the engine as a module
- document structure and extension mechanism in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659424ef9c8329bb155ee5443a0fa1