### PR TITLE
feat: explanatory turn display & selected tile highlighting

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -47,6 +47,10 @@ export class ChessEngine {
     return this._locale().colors[color] || color;
   }
 
+  getTurnLabel() {
+    return this._locale().turn || '';
+  }
+
   addPlugin(plugin) {
     this.plugins.push(plugin);
   }

--- a/engine/locales.js
+++ b/engine/locales.js
@@ -2,36 +2,43 @@ export const LOCALES = {
   en: {
     pieces: { pawn: 'Pawn', rook: 'Rook', knight: 'Knight', bishop: 'Bishop', queen: 'Queen', king: 'King' },
     colors: { white: 'White', black: 'Black' },
-    events: { check: 'Check', checkmate: 'Checkmate' }
+    events: { check: 'Check', checkmate: 'Checkmate' },
+    turn: 'Turn'
   },
   de: {
     pieces: { pawn: 'Bauer', rook: 'Turm', knight: 'Springer', bishop: 'L\u00e4ufer', queen: 'Dame', king: 'K\u00f6nig' },
     colors: { white: 'Wei\u00df', black: 'Schwarz' },
-    events: { check: 'Schach', checkmate: 'Schachmatt' }
+    events: { check: 'Schach', checkmate: 'Schachmatt' },
+    turn: 'Am Zug'
   },
   fr: {
     pieces: { pawn: 'Pion', rook: 'Tour', knight: 'Cavalier', bishop: 'Fou', queen: 'Dame', king: 'Roi' },
     colors: { white: 'Blanc', black: 'Noir' },
-    events: { check: '\u00c9chec', checkmate: '\u00c9chec et mat' }
+    events: { check: '\u00c9chec', checkmate: '\u00c9chec et mat' },
+    turn: 'Tour'
   },
   es: {
     pieces: { pawn: 'Pe\u00f3n', rook: 'Torre', knight: 'Caballo', bishop: 'Alfil', queen: 'Reina', king: 'Rey' },
     colors: { white: 'Blanco', black: 'Negro' },
-    events: { check: 'Jaque', checkmate: 'Jaque mate' }
+    events: { check: 'Jaque', checkmate: 'Jaque mate' },
+    turn: 'Turno'
   },
   it: {
     pieces: { pawn: 'Pedone', rook: 'Torre', knight: 'Cavallo', bishop: 'Alfiere', queen: 'Regina', king: 'Re' },
     colors: { white: 'Bianco', black: 'Nero' },
-    events: { check: 'Scacco', checkmate: 'Scacco matto' }
+    events: { check: 'Scacco', checkmate: 'Scacco matto' },
+    turn: 'Turno'
   },
   zh_TW: {
     pieces: { pawn: '\u5175', rook: '\u8eca', knight: '\u99ac', bishop: '\u8c61', queen: '\u5a66', king: '\u738b' },
     colors: { white: '\u767d', black: '\u9ed1' },
-    events: { check: '\u5c07\u8ecd', checkmate: '\u5c07\u6b7b' }
+    events: { check: '\u5c07\u8ecd', checkmate: '\u5c07\u6b7b' },
+    turn: '\u8ab0\u7684\u56de合'
   },
   uk: {
     pieces: { pawn: '\u041f\u0456\u0448\u0430\u043a', rook: '\u0422\u0443\u0440\u0430', knight: '\u041a\u0456\u043d\u044c', bishop: '\u0421\u043b\u043e\u043d', queen: '\u0424\u0435\u0440\u0437\u044c', king: '\u041a\u043e\u0440\u043e\u043b\u044c' },
     colors: { white: '\u0411\u0456\u043b\u0456', black: '\u0427\u043e\u0440\u043d\u0456' },
-    events: { check: '\u0428\u0430\u0445', checkmate: '\u0428\u0430\u0445 \u0456 \u043c\u0430\u0442' }
+    events: { check: '\u0428\u0430\u0445', checkmate: '\u0428\u0430\u0445 \u0456 \u043c\u0430\u0442' },
+    turn: '\u0425\u0456\u0434'
   }
 };

--- a/web/app.js
+++ b/web/app.js
@@ -28,7 +28,7 @@ let selected = null;
 
 function render() {
   boardEl.innerHTML = '';
-  turnEl.textContent = engine.getColorName(engine.turn);
+  turnEl.textContent = engine.getTurnLabel() + ': ' + engine.getColorName(engine.turn);
   const event = engine.getLastEvent();
   statusEl.textContent = event ? engine.getEventName(event) : '';
   updateCaptured();
@@ -41,6 +41,9 @@ function render() {
       const piece = engine.getPiece(x, y);
       if (piece) {
         square.textContent = pieceSymbols[piece.type][piece.color];
+      }
+      if (selected && selected.x === x && selected.y === y) {
+        square.classList.add('selected');
       }
       square.addEventListener('click', onSquareClick);
       square.addEventListener('mouseover', () => {
@@ -66,10 +69,12 @@ function onSquareClick(e) {
       return;
     }
     selected = null;
+    render();
   } else {
     const piece = engine.getPiece(x, y);
     if (piece && piece.color === engine.turn) {
       selected = { x, y };
+      render();
     }
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,7 @@
     .light { background: #eee; }
     .dark { background: #555; color: white; }
     .square:hover { transform: scale(1.1); cursor: pointer; }
+    .selected { outline: 2px solid red; }
     .status-bar {
       display: flex;
       width: 100%;


### PR DESCRIPTION
## Summary
- localize wording for turn indication
- expose engine.getTurnLabel
- display turn prefix using localization
- show selected square

## Testing
- `npm test`

------
