### PR TITLE
fix: disallow king moving into check

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -69,10 +69,19 @@ export class ChessEngine {
     if (!this.isValidMove(piece, fromX, fromY, toX, toY)) return false;
 
     const target = this.getPiece(toX, toY);
-    if (target) this.captured.push(target);
 
+    // simulate move to ensure it doesn't leave king in check
     this.board[toY][toX] = piece;
     this.board[fromY][fromX] = null;
+    const inCheck = this.isCheck(piece.color);
+    if (inCheck) {
+      this.board[fromY][fromX] = piece;
+      this.board[toY][toX] = target;
+      return false;
+    }
+
+    if (target) this.captured.push(target);
+
     this.turn = this.turn === 'white' ? 'black' : 'white';
     this._checkEvents();
 

--- a/engine/index.js
+++ b/engine/index.js
@@ -75,6 +75,7 @@ export class ChessEngine {
     this.board[fromY][fromX] = null;
     const inCheck = this.isCheck(piece.color);
     if (inCheck) {
+      // revert the move as it is against the rules
       this.board[fromY][fromX] = piece;
       this.board[toY][toX] = target;
       return false;

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -117,3 +117,15 @@ test('pawn cannot capture forward', () => {
   e.board[2][0] = { type: 'pawn', color: 'black' };
   assert.equal(e.move(0,1,0,2), false);
 });
+
+test('king cannot move into check', () => {
+  const e = createEngine();
+  // clear the board
+  e.board = Array.from({ length: 8 }, () => Array(8).fill(null));
+  // place kings and an attacking rook
+  e.board[0][4] = { type: 'king', color: 'white' };
+  e.board[7][4] = { type: 'rook', color: 'black' };
+  e.turn = 'white';
+  // king tries to step into rook's line of fire
+  assert.equal(e.move(4,0,4,1), false);
+});


### PR DESCRIPTION
## Summary
- avoid moves that leave the moving side in check
- add a test ensuring the king can't move into an attacked square

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865b2f94df483298763b4429577e226