### PR TITLE
Add CLI package with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ rules or features.
 ### CLI
 
 For quick testing on the command line a simple CLI is provided in `cli/`.
-Install dependencies and run moves directly without touching JavaScript:
+Install dependencies and run moves directly without touching JavaScript. Moves can
+be written in lowercase or uppercase:
 
 ```bash
 node cli/bin/chessengine.js --moves=e2e4,e7e5

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install dependencies and run moves directly without touching JavaScript. Moves c
 be written in lowercase or uppercase:
 
 ```bash
-node cli/bin/chessengine.js --moves=e2e4,e7e5
+node cli/bin/chessengine.js --moves=e2e4,E7E5
 ```
 
 ## GitHub Pages

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ standard chess rules implemented in the engine. Plugins can hook into the
 `beforeMove` and `afterMove` events of the `ChessEngine` class to introduce new
 rules or features.
 
+### CLI
+
+For quick testing on the command line a simple CLI is provided in `cli/`.
+Install dependencies and run moves directly without touching JavaScript:
+
+```bash
+node cli/bin/chessengine.js --moves=e2e4,e7e5
+```
+
 ## GitHub Pages
 
 The entire repository is automatically deployed to

--- a/cli/bin/chessengine.js
+++ b/cli/bin/chessengine.js
@@ -4,9 +4,11 @@ import readline from 'node:readline/promises';
 import process from 'node:process';
 
 function posToCoord(pos) {
+  // allow both uppercase and lowercase coordinates
+  const p = pos.toLowerCase();
   const files = 'abcdefgh';
-  const x = files.indexOf(pos[0]);
-  const y = Number(pos[1]) - 1;
+  const x = files.indexOf(p[0]);
+  const y = Number(p[1]) - 1;
   return [x, y];
 }
 

--- a/cli/bin/chessengine.js
+++ b/cli/bin/chessengine.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { ChessEngine } from '../../engine/index.js';
+import readline from 'node:readline/promises';
+import process from 'node:process';
+
+function posToCoord(pos) {
+  const files = 'abcdefgh';
+  const x = files.indexOf(pos[0]);
+  const y = Number(pos[1]) - 1;
+  return [x, y];
+}
+
+function usage() {
+  console.log('Usage: chessengine [--moves=a2a4,b7b5]');
+}
+
+const movesArg = process.argv.find(a => a.startsWith('--moves='));
+if (movesArg) {
+  const moves = movesArg.slice('--moves='.length).split(',');
+  const engine = new ChessEngine();
+  for (const m of moves) {
+    const [from, to] = [m.slice(0,2), m.slice(2,4)];
+    const coords = [...posToCoord(from), ...posToCoord(to)];
+    const ok = engine.move(...coords);
+    console.log(ok ? 'ok' : 'invalid');
+    if (engine.getLastEvent()) {
+      console.log(engine.getEventName(engine.getLastEvent()));
+    }
+  }
+  process.exit(0);
+}
+
+if (process.stdin.isTTY) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const engine = new ChessEngine();
+  console.log('Type moves like e2e4. Type "exit" to quit.');
+  async function loop() {
+    const prompt = `${engine.getTurnLabel()} ${engine.getColorName(engine.turn)}> `;
+    const answer = await rl.question(prompt);
+    if (answer === 'exit') { rl.close(); return; }
+    if (answer.length < 4) { console.log('Invalid format'); return loop(); }
+    const [from, to] = [answer.slice(0,2), answer.slice(2,4)];
+    const coords = [...posToCoord(from), ...posToCoord(to)];
+    const ok = engine.move(...coords);
+    console.log(ok ? 'ok' : 'invalid');
+    if (engine.getLastEvent()) {
+      console.log(engine.getEventName(engine.getLastEvent()));
+    }
+    await loop();
+  }
+  loop();
+} else {
+  usage();
+  process.exit(1);
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chessengine-cli",
+  "version": "0.1.0",
+  "bin": {
+    "chessengine": "bin/chessengine.js"
+  },
+  "type": "module",
+  "dependencies": {
+    "chessengine": "file:../engine"
+  }
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -17,7 +17,7 @@ function runCli(args) {
 }
 
 test('runs moves from command line', async () => {
-  const { stdout } = await runCli(['--moves=e2e4,e7e5']);
+  const { stdout } = await runCli(['--moves=E2E4,E7E5']);
   const lines = stdout.trim().split(/\n/);
   assert.equal(lines[0], 'ok');
   assert.equal(lines[1], 'ok');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { execFile } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = join(__dirname, '..', 'cli', 'bin', 'chessengine.js');
+
+function runCli(args) {
+  return new Promise((resolve, reject) => {
+    execFile('node', [cliPath, ...args], { encoding: 'utf8' }, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve({ stdout, stderr });
+    });
+  });
+}
+
+test('runs moves from command line', async () => {
+  const { stdout } = await runCli(['--moves=e2e4,e7e5']);
+  const lines = stdout.trim().split(/\n/);
+  assert.equal(lines[0], 'ok');
+  assert.equal(lines[1], 'ok');
+});
+
+test('detects checkmate via CLI', async () => {
+  const { stdout } = await runCli(['--moves=f2f3,e7e5,g2g4,d8h4']);
+  const lines = stdout.trim().split(/\n/);
+  assert.equal(lines.at(-2), 'ok'); // last move result
+  assert.equal(lines.at(-1), 'Checkmate');
+});


### PR DESCRIPTION
## Summary
- add a CLI plugin with a simple interactive command line
- document the CLI usage in README
- test the new interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865c1ff16b48329842fa68fada2c010