### PR TITLE
fix: disallow same-position moves

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -171,6 +171,9 @@ export class ChessEngine {
     // ensure that the new coordinates are still on the board
     if (![fromX, fromY, toX, toY].every(n => n >= 0 && n < 8)) return false;
 
+    // moving to the same square would effectively pass a turn
+    if (fromX === toX && fromY === toY) return false;
+
     const dx = toX - fromX;
     const dy = toY - fromY;
     const target = this.getPiece(toX, toY);

--- a/engine/index.js
+++ b/engine/index.js
@@ -171,7 +171,7 @@ export class ChessEngine {
     // ensure that the new coordinates are still on the board
     if (![fromX, fromY, toX, toY].every(n => n >= 0 && n < 8)) return false;
 
-    // moving to the same square would effectively pass a turn
+    // moving to the same square would effectively skip a turn
     if (fromX === toX && fromY === toY) return false;
 
     const dx = toX - fromX;

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -152,5 +152,5 @@ test('move outside board is rejected', () => {
 test('stationary move is not allowed', () => {
   const e = createEngine();
   assert.equal(e.move(0,0,0,0), false);
-  assert.equal(e.turn, 'white');
+  assert.equal(e.turn, 'white'); // is it still white's turn?
 });

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -148,3 +148,9 @@ test('move outside board is rejected', () => {
   assert.equal(e.move(0,1,-1,0), false); // different direction
   assert.equal(e.getPiece(0,1).type, 'pawn'); // ensure a pawn exists
 });
+
+test('stationary move is not allowed', () => {
+  const e = createEngine();
+  assert.equal(e.move(0,0,0,0), false);
+  assert.equal(e.turn, 'white');
+});


### PR DESCRIPTION
## Summary
- prevent pieces from remaining on the same square
- add a test covering this rule

## Testing
- `npm test`

------
