### PR TITLE
feat(localization): translate captured and reset labels

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -51,6 +51,19 @@ export class ChessEngine {
     return this._locale().turn || '';
   }
 
+  getCapturedByWhiteLabel() {
+    // rely on default English translations in LOCALES
+    return this._locale().capturedWhite;
+  }
+
+  getCapturedByBlackLabel() {
+    return this._locale().capturedBlack;
+  }
+
+  getResetLabel() {
+    return this._locale().reset;
+  }
+
   addPlugin(plugin) {
     this.plugins.push(plugin);
   }

--- a/engine/locales.js
+++ b/engine/locales.js
@@ -3,42 +3,63 @@ export const LOCALES = {
     pieces: { pawn: 'Pawn', rook: 'Rook', knight: 'Knight', bishop: 'Bishop', queen: 'Queen', king: 'King' },
     colors: { white: 'White', black: 'Black' },
     events: { check: 'Check', checkmate: 'Checkmate' },
-    turn: 'Turn'
+    turn: 'Turn',
+    capturedWhite: 'Captured by white:',
+    capturedBlack: 'Captured by black:',
+    reset: 'Reset'
   },
   de: {
     pieces: { pawn: 'Bauer', rook: 'Turm', knight: 'Springer', bishop: 'L\u00e4ufer', queen: 'Dame', king: 'K\u00f6nig' },
     colors: { white: 'Wei\u00df', black: 'Schwarz' },
     events: { check: 'Schach', checkmate: 'Schachmatt' },
-    turn: 'Am Zug'
+    turn: 'Am Zug',
+    capturedWhite: 'Von Wei\u00df geschlagen:',
+    capturedBlack: 'Von Schwarz geschlagen:',
+    reset: 'Zur\u00fccksetzen'
   },
   fr: {
     pieces: { pawn: 'Pion', rook: 'Tour', knight: 'Cavalier', bishop: 'Fou', queen: 'Dame', king: 'Roi' },
     colors: { white: 'Blanc', black: 'Noir' },
     events: { check: '\u00c9chec', checkmate: '\u00c9chec et mat' },
-    turn: 'Tour'
+    turn: 'Tour',
+    capturedWhite: 'Pris par les blancs :',
+    capturedBlack: 'Pris par les noirs :',
+    reset: '\u00c9initialiser'
   },
   es: {
     pieces: { pawn: 'Pe\u00f3n', rook: 'Torre', knight: 'Caballo', bishop: 'Alfil', queen: 'Reina', king: 'Rey' },
     colors: { white: 'Blanco', black: 'Negro' },
     events: { check: 'Jaque', checkmate: 'Jaque mate' },
-    turn: 'Turno'
+    turn: 'Turno',
+    capturedWhite: 'Capturado por blancas:',
+    capturedBlack: 'Capturado por negras:',
+    reset: 'Reiniciar'
   },
   it: {
     pieces: { pawn: 'Pedone', rook: 'Torre', knight: 'Cavallo', bishop: 'Alfiere', queen: 'Regina', king: 'Re' },
     colors: { white: 'Bianco', black: 'Nero' },
     events: { check: 'Scacco', checkmate: 'Scacco matto' },
-    turn: 'Turno'
+    turn: 'Turno',
+    capturedWhite: 'Catturati dal bianco:',
+    capturedBlack: 'Catturati dal nero:',
+    reset: 'Resetta'
   },
   zh_TW: {
     pieces: { pawn: '\u5175', rook: '\u8eca', knight: '\u99ac', bishop: '\u8c61', queen: '\u5a66', king: '\u738b' },
     colors: { white: '\u767d', black: '\u9ed1' },
     events: { check: '\u5c07\u8ecd', checkmate: '\u5c07\u6b7b' },
-    turn: '\u8ab0\u7684\u56de合'
+    turn: '\u8ab0\u7684\u56de合',
+    capturedWhite: '\u767d\u65b9\u5403\u5b50\uff1a',
+    capturedBlack: '\u9ed1\u65b9\u5403\u5b50\uff1a',
+    reset: '\u91cd\u7f6e'
   },
   uk: {
     pieces: { pawn: '\u041f\u0456\u0448\u0430\u043a', rook: '\u0422\u0443\u0440\u0430', knight: '\u041a\u0456\u043d\u044c', bishop: '\u0421\u043b\u043e\u043d', queen: '\u0424\u0435\u0440\u0437\u044c', king: '\u041a\u043e\u0440\u043e\u043b\u044c' },
     colors: { white: '\u0411\u0456\u043b\u0456', black: '\u0427\u043e\u0440\u043d\u0456' },
     events: { check: '\u0428\u0430\u0445', checkmate: '\u0428\u0430\u0445 \u0456 \u043c\u0430\u0442' },
-    turn: '\u0425\u0456\u0434'
+    turn: '\u0425\u0456\u0434',
+    capturedWhite: '\u0417\u0430\u0445\u043e\u043f\u043b\u0435\u043d\u043e \u0431\u0456\u043b\u0438\u043c\u0438:',
+    capturedBlack: '\u0417\u0430\u0445\u043e\u043f\u043b\u0435\u043d\u043e \u0447\u043e\u0440\u043d\u0438\u043c\u0438:',
+    reset: '\u0421\u043a\u0438\u043d\u0443\u0442\u0438'
   }
 };

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -87,6 +87,13 @@ test('localization translates names', () => {
   assert.equal(e.getEventName('check'), 'Schach');
 });
 
+test('localization translates labels', () => {
+  const e = createEngine();
+  e.setLanguage('es');
+  assert.equal(e.getCapturedByWhiteLabel(), 'Capturado por blancas:');
+  assert.equal(e.getResetLabel(), 'Reiniciar');
+});
+
 test('rook movement and blocking', () => {
   const e = createEngine();
   assert.equal(e.move(0,0,0,2), false); // blocked by pawn

--- a/web/app.js
+++ b/web/app.js
@@ -8,12 +8,17 @@ const infoEl = document.getElementById('info');
 const statusEl = document.getElementById('status');
 const capWhiteEl = document.getElementById('captured-white');
 const capBlackEl = document.getElementById('captured-black');
+const capWhiteLabelEl = document.getElementById('captured-white-label');
+const capBlackLabelEl = document.getElementById('captured-black-label');
 const resetBtn = document.getElementById('reset');
 
 const engine = new ChessEngine();
 engine.addPlugin(new LoggerPlugin());
 const lang = (navigator.language || 'en').split('-')[0];
 if (LOCALES[lang]) engine.setLanguage(lang);
+capWhiteLabelEl.textContent = engine.getCapturedByWhiteLabel();
+capBlackLabelEl.textContent = engine.getCapturedByBlackLabel();
+resetBtn.textContent = engine.getResetLabel();
 
 const pieceSymbols = {
   pawn:   { white: '♙', black: '♟' },

--- a/web/index.html
+++ b/web/index.html
@@ -40,12 +40,12 @@
   </div>
   <div id="board"></div>
   <div>
-    <strong>Captured by white:</strong> <span id="captured-white"></span>
+    <strong id="captured-white-label"></strong> <span id="captured-white"></span>
   </div>
   <div>
-    <strong>Captured by black:</strong> <span id="captured-black"></span>
+    <strong id="captured-black-label"></strong> <span id="captured-black"></span>
   </div>
-  <button id="reset">Reset</button>
+  <button id="reset"></button>
   <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add web labels to `LOCALES`
- expose helper methods for label localization
- set localized labels in the demo
- test new localization API

## Testing
- `npm test`


------
