### PR TITLE
fix: artifact action version deprecated

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 18
       - run: npm test
         # Ensure the build only proceeds if tests succeed
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v2
         with:
           path: '.'
 


### PR DESCRIPTION
## Summary
- use `actions/upload-pages-artifact@v2` to avoid deprecated artifact version

## Testing
- `npm test`

------
