### PR TITLE
Add CLI language switch and reset feature

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -14,13 +14,15 @@ function posToCoord(pos) {
 }
 
 function usage() {
-  console.log('Usage: chessengine [--moves=a2a4,b7b5]');
+  console.log('Usage: chessengine [--moves=a2a4,b7b5] [--lang=de]');
 }
 
 const movesArg = process.argv.find(a => a.startsWith('--moves='));
+const langArg = process.argv.find(a => a.startsWith('--lang='));
 if (movesArg) {
   const moves = movesArg.slice('--moves='.length).split(',');
   const engine = new ChessEngine();
+  if (langArg) engine.setLanguage(langArg.slice('--lang='.length));
   for (const m of moves) {
     const [from, to] = [m.slice(0,2), m.slice(2,4)];
     const coords = [...posToCoord(from), ...posToCoord(to)];
@@ -37,6 +39,7 @@ if (!movesArg) {
   // Start interactive REPL when no moves are provided.
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   const engine = new ChessEngine();
+  if (langArg) engine.setLanguage(langArg.slice('--lang='.length));
   console.log('Type moves like e2e4. Type "help" for commands.');
 
   // Convert internal piece representation to a single character.
@@ -67,11 +70,21 @@ if (!movesArg) {
     const answer = (await rl.question(prompt)).trim();
     if (answer === 'exit') { rl.close(); return; }
     if (answer === 'help') {
-      console.log('Commands: help, board, exit, <move>');
+      console.log('Commands: help, board, lang <code>, reset, exit, <move>');
       return loop();
     }
     if (answer === 'board') {
       showBoard();
+      return loop();
+    }
+    if (answer.startsWith('lang ')) {
+      const code = answer.split(/\s+/)[1];
+      if (code) engine.setLanguage(code);
+      return loop();
+    }
+    if (answer === 'reset') {
+      engine.reset();
+      console.log(engine.getResetLabel());
       return loop();
     }
     if (answer.length < 4) { console.log('Invalid format'); return loop(); }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -54,3 +54,19 @@ test('board command prints initial board', async () => {
   const { stdout } = await runCliInteractive(['board', 'exit']);
   assert.ok(stdout.includes('r n b q k b n r 8'));
 });
+
+test('language parameter localizes output', async () => {
+  const { stdout } = await runCli(['--lang=de', '--moves=f2f3,e7e5,g2g4,d8h4']);
+  const lines = stdout.trim().split(/\n/);
+  assert.equal(lines.at(-1), 'Schachmatt');
+});
+
+test('interactive lang command changes prompt language', async () => {
+  const { stdout } = await runCliInteractive(['lang de']);
+  assert.ok(stdout.includes('Am Zug'));
+});
+
+test('interactive reset command prints label', async () => {
+  const { stdout } = await runCliInteractive(['reset']);
+  assert.ok(stdout.includes('Reset'));
+});


### PR DESCRIPTION
## Summary
- support `--lang` parameter for localized output
- enable `lang <code>` and `reset` commands in interactive CLI
- test interactive language switch and reset command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68684980104083299a6935cacf2eae0a