### PR TITLE
Add captured pieces command to CLI

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -61,17 +61,30 @@ if (!movesArg) {
     console.log(files.split('').join(' '));
   }
 
+  function showCaptured() {
+    const caps = engine.getCaptured();
+    // pieces captured by white are black pieces
+    const byWhite = caps.filter(p => p.color === 'black').map(pieceChar).join(' ');
+    const byBlack = caps.filter(p => p.color === 'white').map(pieceChar).join(' ');
+    console.log(engine.getCapturedByWhiteLabel(), byWhite || '-');
+    console.log(engine.getCapturedByBlackLabel(), byBlack || '-');
+  }
+
   async function loop() {
     // Show the turn label with color name in parentheses
     const prompt = `${engine.getTurnLabel()} (${engine.getColorName(engine.turn)})> `;
     const answer = (await rl.question(prompt)).trim();
     if (answer === 'exit') { rl.close(); return; }
     if (answer === 'help') {
-      console.log('Commands: help, board, exit, <move>');
+      console.log('Commands: help, board, captured, exit, <move>');
       return loop();
     }
     if (answer === 'board') {
       showBoard();
+      return loop();
+    }
+    if (answer === 'captured') {
+      showCaptured();
       return loop();
     }
     if (answer.length < 4) { console.log('Invalid format'); return loop(); }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -24,10 +24,12 @@ function runCliInteractive(commands) {
     child.stdout.on('data', data => { stdout += data; });
     child.on('error', reject);
     child.on('close', () => resolve({ stdout }));
+    let delay = 0;
     for (const cmd of commands) {
-      child.stdin.write(cmd + '\n');
+      setTimeout(() => child.stdin.write(cmd + '\n'), delay);
+      delay += 50; // small delay to allow readline processing
     }
-    child.stdin.end();
+    setTimeout(() => child.stdin.end(), delay);
   });
 }
 
@@ -53,4 +55,10 @@ test('interactive help output', async () => {
 test('board command prints initial board', async () => {
   const { stdout } = await runCliInteractive(['board', 'exit']);
   assert.ok(stdout.includes('r n b q k b n r 8'));
+});
+
+test('captured command shows captured pieces', async () => {
+  const cmds = ['e2e4', 'd7d5', 'e4d5', 'captured', 'exit'];
+  const { stdout } = await runCliInteractive(cmds);
+  assert.ok(stdout.includes('Captured by white: p'));
 });


### PR DESCRIPTION
## Summary
- show captured pieces in CLI with new `captured` command
- update CLI help message
- delay CLI test input for readline
- test captured pieces output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686b00ba71a48329b39b4b629d0b465e