### PR TITLE
Fix README not converted to HTML

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,12 +19,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: npm test
         # Ensure the build only proceeds if tests succeed
+      - name: Copy README.md to index.md
+        # Jekyll builds from index.md by default
+        run: cp README.md index.md
+      - uses: actions/configure-pages@v5
+        # Prepare Pages to build the site using Jekyll
       - uses: actions/upload-pages-artifact@v3
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:


### PR DESCRIPTION
## Summary
- ensure GitHub Pages runs the Jekyll build
- copy README.md so Jekyll can render it as the index page
- upgrade GitHub Pages actions versions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686da093a95c83299158dd9a3ebd53a8