### PR TITLE
Expose CLI in browser console

### DIFF
--- a/cli/core.js
+++ b/cli/core.js
@@ -1,0 +1,62 @@
+import { ChessEngine } from '../engine/index.js';
+
+export class ChessCLI {
+  constructor(lang) {
+    this.engine = new ChessEngine();
+    if (lang) this.engine.setLanguage(lang);
+  }
+
+  posToCoord(pos) {
+    const p = pos.toLowerCase();
+    const files = 'abcdefgh';
+    const x = files.indexOf(p[0]);
+    const y = Number(p[1]) - 1;
+    return [x, y];
+  }
+
+  pieceChar(piece) {
+    const map = { pawn: 'p', rook: 'r', knight: 'n', bishop: 'b', queen: 'q', king: 'k' };
+    const ch = map[piece.type] || '?';
+    return piece.color === 'white' ? ch.toUpperCase() : ch;
+  }
+
+  board() {
+    const files = 'abcdefgh';
+    for (let y = 7; y >= 0; y--) {
+      let row = '';
+      for (let x = 0; x < 8; x++) {
+        const p = this.engine.getPiece(x, y);
+        row += (p ? this.pieceChar(p) : '.') + ' ';
+      }
+      console.log(row.trim(), y + 1);
+    }
+    console.log(files.split('').join(' '));
+  }
+
+  getPrompt() {
+    return `${this.engine.getTurnLabel()} (${this.engine.getColorName(this.engine.turn)})> `;
+  }
+
+  move(cmd) {
+    const [from, to] = [cmd.slice(0, 2), cmd.slice(2, 4)];
+    const coords = [...this.posToCoord(from), ...this.posToCoord(to)];
+    const ok = this.engine.move(...coords);
+    console.log(ok ? 'ok' : 'invalid');
+    if (this.engine.getLastEvent()) {
+      console.log(this.engine.getEventName(this.engine.getLastEvent()));
+    }
+  }
+
+  lang(code) {
+    if (code) this.engine.setLanguage(code);
+  }
+
+  reset() {
+    this.engine.reset();
+    console.log(this.engine.getResetLabel());
+  }
+
+  help() {
+    console.log('Commands: help, board, lang <code>, reset, exit, <move>');
+  }
+}

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,17 +1,7 @@
 #!/usr/bin/env node
-// Import the engine one directory up
-import { ChessEngine } from '../engine/index.js';
+import { ChessCLI } from './core.js';
 import readline from 'node:readline/promises';
 import process from 'node:process';
-
-function posToCoord(pos) {
-  // allow both uppercase and lowercase coordinates
-  const p = pos.toLowerCase();
-  const files = 'abcdefgh';
-  const x = files.indexOf(p[0]);
-  const y = Number(p[1]) - 1;
-  return [x, y];
-}
 
 function usage() {
   console.log('Usage: chessengine [--moves=a2a4,b7b5] [--lang=de]');
@@ -19,82 +9,27 @@ function usage() {
 
 const movesArg = process.argv.find(a => a.startsWith('--moves='));
 const langArg = process.argv.find(a => a.startsWith('--lang='));
+const cli = new ChessCLI(langArg && langArg.slice('--lang='.length));
+
 if (movesArg) {
   const moves = movesArg.slice('--moves='.length).split(',');
-  const engine = new ChessEngine();
-  if (langArg) engine.setLanguage(langArg.slice('--lang='.length));
-  for (const m of moves) {
-    const [from, to] = [m.slice(0,2), m.slice(2,4)];
-    const coords = [...posToCoord(from), ...posToCoord(to)];
-    const ok = engine.move(...coords);
-    console.log(ok ? 'ok' : 'invalid');
-    if (engine.getLastEvent()) {
-      console.log(engine.getEventName(engine.getLastEvent()));
-    }
-  }
+  for (const m of moves) cli.move(m);
   process.exit(0);
 }
 
 if (!movesArg) {
-  // Start interactive REPL when no moves are provided.
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  const engine = new ChessEngine();
-  if (langArg) engine.setLanguage(langArg.slice('--lang='.length));
   console.log('Type moves like e2e4. Type "help" for commands.');
 
-  // Convert internal piece representation to a single character.
-  // White pieces are printed in uppercase.
-  function pieceChar(piece) {
-    const map = { pawn: 'p', rook: 'r', knight: 'n', bishop: 'b', queen: 'q', king: 'k' };
-    const ch = map[piece.type] || '?';
-    return piece.color === 'white' ? ch.toUpperCase() : ch;
-  }
-
-  function showBoard() {
-    // Print board from Black's perspective at the top.
-    const files = 'abcdefgh';
-    for (let y = 7; y >= 0; y--) {
-      let row = '';
-      for (let x = 0; x < 8; x++) {
-        const p = engine.getPiece(x, y);
-        row += (p ? pieceChar(p) : '.') + ' ';
-      }
-      console.log(row.trim(), y + 1);
-    }
-    console.log(files.split('').join(' '));
-  }
-
   async function loop() {
-    // Show the turn label with color name in parentheses
-    const prompt = `${engine.getTurnLabel()} (${engine.getColorName(engine.turn)})> `;
-    const answer = (await rl.question(prompt)).trim();
+    const answer = (await rl.question(cli.getPrompt())).trim();
     if (answer === 'exit') { rl.close(); return; }
-    if (answer === 'help') {
-      console.log('Commands: help, board, lang <code>, reset, exit, <move>');
-      return loop();
-    }
-    if (answer === 'board') {
-      showBoard();
-      return loop();
-    }
-    if (answer.startsWith('lang ')) {
-      const code = answer.split(/\s+/)[1];
-      if (code) engine.setLanguage(code);
-      return loop();
-    }
-    if (answer === 'reset') {
-      engine.reset();
-      console.log(engine.getResetLabel());
-      return loop();
-    }
+    if (answer === 'help') { cli.help(); return loop(); }
+    if (answer === 'board') { cli.board(); return loop(); }
+    if (answer.startsWith('lang ')) { cli.lang(answer.split(/\s+/)[1]); return loop(); }
+    if (answer === 'reset') { cli.reset(); return loop(); }
     if (answer.length < 4) { console.log('Invalid format'); return loop(); }
-    const [from, to] = [answer.slice(0,2), answer.slice(2,4)];
-    const coords = [...posToCoord(from), ...posToCoord(to)];
-    const ok = engine.move(...coords);
-    console.log(ok ? 'ok' : 'invalid');
-    if (engine.getLastEvent()) {
-      console.log(engine.getEventName(engine.getLastEvent()));
-    }
+    cli.move(answer);
     return loop();
   }
   loop();

--- a/web/console.js
+++ b/web/console.js
@@ -1,0 +1,5 @@
+import { ChessCLI } from '../cli/core.js';
+
+window.chess = new ChessCLI();
+console.log('Chess CLI loaded. Use the `chess` object in the console.');
+console.log('Type chess.help() for available commands.');

--- a/web/index.html
+++ b/web/index.html
@@ -46,6 +46,8 @@
     <strong id="captured-black-label"></strong> <span id="captured-black"></span>
   </div>
   <button id="reset"></button>
+  <p style="font-size: small; color: gray;">Open your browser console to use the command line via <code>chess</code>.</p>
   <script type="module" src="app.js"></script>
+  <script type="module" src="console.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- share CLI logic in a new `ChessCLI` class
- use the new class for the Node CLI
- expose the CLI through `web/console.js`
- hint on the web page about the console

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb405dccc8329a4b8827180c33d98